### PR TITLE
fix Dracula.xml URL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,6 +13,6 @@ If you are a git user, you can install the theme and keep up to date by cloning 
 #### Activating theme
 
 1.  Go to `%AppData%\Notepad++\themes` (%AppData% is platform dependent environment variable. Open a Command Prompt and execute `echo %AppData%`)
-2.  Place `Dracula.xml` inside that folder
+2.  Place [`Dracula.xml`](https://raw.githubusercontent.com/dracula/notepad-plus-plus/master/Dracula.xml) inside that folder
 3.  Restart Notepad++
 4.  Dracula will be available in `Settings > Style Configurator`


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4165489/97179816-a57a5a80-176f-11eb-9fb5-02b9161e8c52.png)

On https://draculatheme.com/notepad-plus-plus "Dracula.xml" is written twice in blue (making me think they both were hyperlinks) but the second one isn't clickable. This change makes Dracula.xml clickable in both locations on the page.

PS: I've been fighting one-line PR spam in my repos since October 1, and I hesitated to make this PR because I don't want it to get misinterpreted as that. I actually tried to download this XML file today and struggled because I got confused on the website.