### PR TITLE
Add NFO support

### DIFF
--- a/Dracula.xml
+++ b/Dracula.xml
@@ -488,6 +488,9 @@
             <WordsStyle name="OPERATORS" styleID="6" fgColor="8BE9FD" bgColor="282A36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="UNKNOWN: ERROR" styleID="31" fgColor="F1FA8C" bgColor="282A36" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
+        <LexerType name="nfo" desc="Dos Style" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F2" bgColor="282A36" fontSize="" fontStyle="0" />
+        </LexerType>
     </LexerStyles>
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->


### PR DESCRIPTION
Currently, NFO files are displayed as simply black background. Only way to read the text is by selecting some or all of it. This patch adds an appropriate style to deal with NFO files, making the text visible again.

Before:

![before](https://user-images.githubusercontent.com/10922171/150657963-69294253-9795-4d17-aac2-6dd8e772d5aa.png)

After:

![after](https://user-images.githubusercontent.com/10922171/150657984-3ddf928f-48d1-421e-8ad8-c88a291acfc9.png)

The example for NFO file is taken from [here](https://github.com/planbnet/QuickNFO/blob/c2776f3cdc4b41979d10112179c239ae33053ea4/examples/CPN-LGC.NFO).
