### PR TITLE
Fix current line bgcolor same as select bgcolor

### DIFF
--- a/Dracula.xml
+++ b/Dracula.xml
@@ -530,7 +530,7 @@
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="6272A4" bgColor="282A36" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="F8F8F2" bgColor="BD93F9" fontName="" fontStyle="1" fontSize="10" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="F8F8F2" bgColor="FF5555" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="44475A" fgColor="F8F8F2" fontSize="" fontStyle="0" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2F3142" fgColor="F8F8F2" fontSize="" fontStyle="0" />
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="44475A" fgColor="F8F8F2" fontStyle="0" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="F8F8F2" bgColor="282A36" fontStyle="0" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="F8F8F2" bgColor="282A36" fontSize="" fontStyle="0" />


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

fixed #57 

before:
![image](https://github.com/user-attachments/assets/206bf353-e690-4979-b2a6-a4bc4efe1907)
(Selection not visible)

after:
![image](https://github.com/user-attachments/assets/aa5f70f6-5c62-4471-99b5-80cfaf2cf428)
