### PR TITLE
Dracula - Fix active tab text color being unreadable

### DIFF
--- a/generated/Alucard.xml
+++ b/generated/Alucard.xml
@@ -1020,7 +1020,7 @@
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="644AC9" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="E2DECA" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="5A5640" fontName="" fontSize=""></WidgetStyle>
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="1F1F1F" bgColor="E2DECA" fontName="" fontSize=""></WidgetStyle>
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="FFFBEB" bgColor="E2DECA" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="1F1F1F" bgColor="FFFBEB" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Tab color 1" styleID="0" bgColor="846E15" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Tab color 2" styleID="0" bgColor="A34D14" fontName="" fontSize=""></WidgetStyle>

--- a/generated/Alucard.xml
+++ b/generated/Alucard.xml
@@ -11,7 +11,7 @@
 <!--
   Style name:   	Alucard
   Author:       	Dracula Theme
-  Date:         	May 28, 2026
+  Date:         	Jun 26, 2026
   License:      	MIT (https://choosealicense.com/licenses/mit/)
   Description:  	A light theme style based on the Dracula Theme color palette
   Languages:    	Should work with all languages without issue but hasn't been tested on absolutely every one of them.

--- a/generated/Dracula.xml
+++ b/generated/Dracula.xml
@@ -11,7 +11,7 @@
 <!--
   Style name:   	Dracula
   Author:       	Dracula Theme
-  Date:         	May 28, 2026
+  Date:         	Jun 26, 2026
   License:      	MIT (https://choosealicense.com/licenses/mit/)
   Description:  	A dark theme style based on the Dracula Theme color palette
   Languages:    	Should work with all languages without issue but hasn't been tested on absolutely every one of them.
@@ -1020,7 +1020,7 @@
         <WidgetStyle name="Mark Style 5" styleID="21" bgColor="BD93F9" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="353746" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="7C8EB2" fontName="" fontSize=""></WidgetStyle>
-        <WidgetStyle name="Active tab text" styleID="0" fgColor="F8F8F2" bgColor="353746" fontName="" fontSize=""></WidgetStyle>
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="282A36" bgColor="353746" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="F8F8F2" bgColor="282A36" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Tab color 1" styleID="0" bgColor="F1FA8C" fontName="" fontSize=""></WidgetStyle>
         <WidgetStyle name="Tab color 2" styleID="0" bgColor="FFB86C" fontName="" fontSize=""></WidgetStyle>

--- a/themes/alucard.ts
+++ b/themes/alucard.ts
@@ -41,7 +41,7 @@ export const alucardTheme: ThemeDefinition = {
     markupDelimiter: "2A6B45",
     markupAttribute: "036A96",
     tagAttributeChrome: "C5CDE0",
-    activeTabText: "1F1F1F",
+    activeTabText: "FFFBEB",
   },
   fontName: "Consolas",
   fontSize: "10",

--- a/themes/alucard.ts
+++ b/themes/alucard.ts
@@ -41,6 +41,7 @@ export const alucardTheme: ThemeDefinition = {
     markupDelimiter: "2A6B45",
     markupAttribute: "036A96",
     tagAttributeChrome: "C5CDE0",
+    activeTabText: "1F1F1F",
   },
   fontName: "Consolas",
   fontSize: "10",

--- a/themes/dracula.ts
+++ b/themes/dracula.ts
@@ -41,6 +41,7 @@ export const draculaTheme: ThemeDefinition = {
     markupDelimiter: "56987A",
     markupAttribute: "8BE9FD",
     tagAttributeChrome: "666B8A",
+    activeTabText: "282A36",
   },
   fontName: "Consolas",
   fontSize: "10",

--- a/themes/template.ts
+++ b/themes/template.ts
@@ -1388,7 +1388,7 @@ export const globalStylesTemplate: GlobalStyleDef[] = [
   { name: "Mark Style 5", styleID: "21", bgColorKey: "purple" },
   { name: "Incremental highlight all", styleID: "28", bgColorKey: "incrementalHighlight" },
   { name: "Active tab unfocused indicator", styleID: "0", fgColorKey: "comment" },
-  { name: "Active tab text", styleID: "0", fgColorKey: "foreground", bgColorKey: "lineHighlight" },
+  { name: "Active tab text", styleID: "0", fgColorKey: "activeTabText", bgColorKey: "lineHighlight" },
   { name: "Inactive tabs", styleID: "0", fgColorKey: "foreground", bgColorKey: "background" },
   { name: "Tab color 1", styleID: "0", bgColorKey: "yellow" },
   { name: "Tab color 2", styleID: "0", bgColorKey: "orange" },

--- a/themes/theme-types.ts
+++ b/themes/theme-types.ts
@@ -62,6 +62,8 @@ export interface ColorPalette {
    * Background for the GlobalStyles “Tags attribute” highlight (paired tag / attribute chrome).
    */
   tagAttributeChrome: string;
+
+  activeTabText: string;
 }
 
 /**


### PR DESCRIPTION
Related to issue #77 

**Issue:**
Commit d989d10 changed the `Active tab text` `fgColorKey` in `template.ts` from `background` to `foreground`. On Dracula, `foreground` is `F8F8F2` (near-white), which is unreadable against the system-drawn active tab background, resulting in invisible tab text.

<img width="514" height="211" alt="image" src="https://github.com/user-attachments/assets/6098a3de-bcbc-46b8-bf9b-22cf437f9257" />


**Fix:**
Added a dedicated `activeTabText` color key to both theme files and updated `template.ts` to use `fgColorKey: "activeTabText"` for the `Active tab text` style. This gives the color an explicit, semantically correct name rather than reusing an unrelated property.

- `dracula.ts` — `activeTabText: "282A36"`
- `alucard.ts` — `activeTabText: "1F1F1F"`

**Files changed:**
- `themes/dracula.ts` — added `activeTabText: "282A36"`
- `themes/alucard.ts` — added `activeTabText: "1F1F1F"`
- `themes/template.ts` — changed `Active tab text` fgColorKey to `"activeTabText"`
- `themes/template-types.ts` - Added `activeTabText` to `ColorPalette`
- `generated/Dracula.xml` — regenerated
- `generated/Alucard.xml` — regenerated

<img width="664" height="240" alt="image" src="https://github.com/user-attachments/assets/da735524-7971-48b3-ac58-c75493641d77" />
